### PR TITLE
Fixed logic error in max records, bumped version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sru-queryer"
-version = "1.0.2"
+version = "1.0.3"
 description = "A utility for integrating SRU queries into your applications."
 readme = "readme.md"
 requires-python = ">=3.7.17"

--- a/src/sru_queryer/_base/_sru_validator.py
+++ b/src/sru_queryer/_base/_sru_validator.py
@@ -124,14 +124,9 @@ class SRUValidator(SRUValidatorAbstract):
         if start_record and start_record < 1:
             raise ValueError("Start record must be greater than 0.")
 
-        if maximum_record:
-            if start_record:
-                if maximum_record < start_record:
-                    raise ValueError("Maximum record must be greater than start record.")
-            
-            if sru_configuration.max_records_supported:
-                if maximum_record > sru_configuration.max_records_supported:
-                    raise ValueError(f"Maximum records returned must be less than {str(sru_configuration.max_records_supported)}.") 
+        if maximum_record and sru_configuration.max_records_supported:
+            if maximum_record > sru_configuration.max_records_supported:
+                raise ValueError(f"Maximum records returned must be less than {str(sru_configuration.max_records_supported)}.") 
         
         if record_schema:
             if record_schema not in sru_configuration.available_record_schemas:


### PR DESCRIPTION
Previously, there was a clause that would raise an error in validation in the event maximum_record was greater than start_record in a query. This was based off the misunderstanding that maximum_record is the upper limit rather than a quantity.

I have fixed this error. This variable will be refactored in 2.0.0.