### PR TITLE
Refactor interface and update documentation.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Using this utility has a few big benefits, such as:
 
 1. It handles validating much of the searchRetrieve request. This is particularly helpful because many SRU servers don't have good error messages.
 2. It handles formatting the searchRetrieve request for you. This makes queries much less prone to human mistakes.
-3. See the capabilities of the SRU server.
+3. Programmatically the capabilities of the SRU server in your program.
 
 ## TABLE OF CONTENTS
 
@@ -190,6 +190,12 @@ You MUST include either:
 `from sru_queryer import SRUQueryer`
 
 The SRUQueryer is the most important class of this library, as it handles configuring the utility as well as constructing, validating, and sending requests.
+
+The SRUQueryer stores all its configuration information in an SRUConfiguration object in the property sru_configuration. If you want your program to know the capabilites of the SRU server, it can read the properties of queryer.sru_configuration. For instance, you can access the available record schemas with:<br>
+
+`queryer.sru_configuration.available_record_schemas`<br>
+
+It is HIGHLY recommended not to change any of these values.
 
 #### INITIALIZATION OPTIONS
 

--- a/readme.md
+++ b/readme.md
@@ -451,7 +451,7 @@ It is not recommended to change any options manually after initializing a Modifi
 | value       | string or None | No        | The value used in the modifier condition.                                                                               |
 | context_set | string or None | No        | The context set that the base_name should be pulled from.                                                               |
 
-COMBINATIONS OF INITIALIZATION PROPERTIES (implied from LOC standards):
+COMBINATIONS OF INITIALIZATION PROPERTIES (implied from LOC standards):<br>
 You MUST include either:
 
 1. a base_name,

--- a/readme.md
+++ b/readme.md
@@ -15,12 +15,11 @@ Using this utility has a few big benefits, such as:
 3. [Quick Overview of Important Components](#quick-overview-of-important-components)
    1. [Initializing SRU Functionality](#initializing-sru-functionality)
    2. [Basic Query Component](#basic-query-component-searchclause)
-   3. [Configuration Service](#configuration-service-sruutil)
-   4. [SearchRetreive class](#creating-queries---the-searchretrieve-class)
-   5. [Boolean Operators for Queries](#constructing-more-advanced-queries-boolean-operators)
+   3. [Searching using SRUQueryer](#searching-using-sruqueryer)
+   4. [Boolean Operators for Queries](#constructing-more-advanced-queries-boolean-operators)
 4. [Full Overview of Different Components](#full-overview-of-different-components)
    1. [SearchClause](#basic-query-component-searchclause-1)
-   2. [SRUUtil](#sruutil)
+   2. [SRUQueryer](#sruqueryer)
    3. [Boolean Operators (AND, OR, NOT, PROX)](#constructing-more-advanced-queries-boolean-operators-1)
    4. [SearchRetrieve](#searchretrieve-class)
    5. [RawCQL](#custom-queries-rawcql)
@@ -40,24 +39,15 @@ Here's just a basic usage example:
 
 ```
 # Create a configuration object for the SRU server, allowing you to validate and send queries.
-sru_configuration = SRUUtil.create_configuration_for_server("https://path-to-sru-server-base")
+queryer = SRUQueryer("https://path-to-sru-server-base")
 
 # Configure a SearchRetrieve query - in this case, find records where the creator includes Abraham, sorted alphabetically & ascending.
-query_obj = SearchRetrieve(sru_configuration, SearchClause(
-        "alma", "creator", "=", "Abraham"), sort_queries=[{
-            "index_set": "alma",
-            "index_name": "creator",
-            "sort_order": "ascending"
-        }])
-
-# Validate the query to see whether it's valid
-query_obj.validate()
-
-# Construct the request (just a python PreparedRequest object)
-request = query_obj.construct_request()
-
-s = Session()
-response = s.send(request)
+response_content = queryer.search_retrieve(SearchClause("alma", "creator", "=", "Abraham"),
+                     sort_queries=[{
+                           "index_set": "alma",
+                           "index_name": "creator",
+                           "sort_order": "ascending"
+                     }])
 ```
 
 This code will send the following query:
@@ -67,47 +57,57 @@ You can also create a query with boolean conditions:
 
 ```
 # Find records where the creator includes Abraham AND the material type is 'book'
-query_obj = SearchRetreive(sru_configuration, AND(SearchClause("alma", "creator", "=", "Abraham"), SearchClause("alma", "materialType", "==", "BOOK")))
+queryer.search_retrieve(sru_configuration, AND(SearchClause("alma", "creator", "=", "Abraham"), SearchClause("alma", "materialType", "==", "BOOK")))
 ```
 
 ## Quick Overview of Important Components:
 
 ### Initializing SRU functionality
 
-Before you can validate or send searchRetrieve requests, you must create an SRU configuration for your server. The configuration of this server will be in the form of an SRUConfiguration class.
-
-An instance is created through the SRUUtil.create_configuration_for_server() function, and all you have to do is to pass the created instance to the functions that need it. You can read information from it if you want to integrate SRU querying more deeply into your application.
+Before you can validate or send searchRetrieve requests, you must create a queryer. Upon initialization, the queryer will contact your SRU server and set up everything it needs to validate and format your SRU queries.
 
 ```
-sru_configuration = SRUUtil.create_configuration_for_server("https://path-to-sru-server-base")
+SRUQueryer("https://path-to-sru-server-base")
 ```
 
-This is the most basic way to create a configuration object. This function takes many other optional arguments, which can do things like configure the default record schemas, default context sets, change validation settings, etc.
+This is the most basic way to create a queryer. This function takes many other optional arguments, which can do things like configure the default record schemas, default context sets, change validation settings, etc.
 
 ### Basic Query Component: SearchClause
 
 `from sru_queryer.cql import SearchClause`
 
 This is officially known as a 'CQL search clause': https://www.loc.gov/standards/sru/cql/spec.html <br>
-A standard CQL search clause looks like: `alma.title="Harry Potter"`. This same query with the SearchClause class would look like: `SearchClause("alma", "title", "=", "Harry Potter")`
+A standard CQL search clause looks like: `alma.title="Harry Potter"`. This same query with the SearchClause class would look like: `SearchClause("alma", "title", "=", "Harry Potter")`. Pretty straightforward! See more in the extended SearchClause section below - there's rules for while of these arguments are required or not.
 
-https://www.loc.gov/standards/sru/cql/spec.html
+### Searching using SRUQueryer
 
-### Creating queries - the SearchRetrieve class
+`from sru_queryer import SRUQueryer`
 
-`from sru_queryer import SearchRetrieve`
+There's two options for conducting searchRetrieve requests with the SRUQueryer class. \
 
-Use the SearchRetrieve class to actually construct and validate a query.\
-This class takes the SRU configuration as an argument, followed by the actual CQL query made up of boolean operators, RawCQL classes, and/or SearchClauses. You can also set certain values that you might want to change between queries while keeping the same SRUConfiguration - record format, start record, maximum records, etc. It also takes sort queries.
+First, you can have the queryer send the request for you and return the content. Once the querier is initialized, you can do so in this way (this is only an example search, it doesn't have to look exactly like this):
 
 ```
-query_obj = SearchRetrieve(sru_configuration, SearchClause(
+response_content = queryer.search_retrieve(SearchClause("alma", "creator", "=", "Abraham"),
+         sort_queries=[{
+            "index_set": "alma",
+            "index_name": "creator",
+            "sort_order": "ascending"
+        }])
+```
+
+Alternately, you can construct a requests.Request query that you can then send yourself. This allows for a bit more flexibility, like modifying the created requests if they don't quite fit your needs:
+
+```
+request = queryer.construct_search_retrieve_request(SearchClause(
         "alma", "creator", "=", "Abraham"), sort_queries=[{
             "index_set": "alma",
             "index_name": "creator",
             "sort_order": "ascending"
         }])
 ```
+
+Both of these options take the same arguments. The first is the CQL query made up of boolean operators, RawCQL classes, and/or SearchClauses. You can also set certain values that you might want to change between queries while keeping the same queryer - record format, start record, maximum records, etc. It also takes sort queries.
 
 ### Constructing more advanced queries: Boolean Operators
 
@@ -120,11 +120,16 @@ For example, the query:
 will produce the following string, when formatted:
 `alma.title="Harry" or alma.title="Potter"` (except spaces will be replaced with '%20')
 
+<br>
+<br>
+
 ---
 
 ## Full Overview of Different Components
 
 This section will give a deep dive on each different component in sru_queryer. Check here if you can't figure something out!
+
+<br>
 
 ### Basic Query Component: SearchClause
 
@@ -138,24 +143,24 @@ The four components of this query are the context_set (`alma`), the index (`titl
 
 #### USAGE
 
-All of the options for initializing a SearchClause are keyword arguments, but are listed in an order that's the same as a standard index query (aside from modifiers).
+All of the options for initializing a SearchClause are keyword arguments, but are listed in order.
 This means you can initialize a SearchClause in a human-readable way without including any keywords:
 `SearchClause("alma", "title", "=", "Harry Potter")`
 which looks like the formatted query:
 `alma.title="Harry Potter"`.
 
-For queries without all options, you have to include the option name for each option OR include 'None' where the option would be.
-Query with only a value:
+For SearchClauses without all options, you have to include the option name for each option OR include 'None' where the option would be.
+SearchClause with only a value:
 `SearchClause(value="Harry Potter")` or `SearchClause(None, None, None, "Harry Potter")`
-Query without a context_set:
+SearchClause without a context_set:
 `SearchClause(index_name="title", operation="=", value="Harry Potter")` or
 `SearchClause(None, "title", "=", "Harry Potter")`
 
-Keep in mind, if a context_set or index_name is not provided, the defaults must be set manually though create_configuration_for_server for validation to work. This is because the explainResponse does not always include the default context set or index. If you do not know them, there are options to disable validation for SearchClauses that use defaults.
+Keep in mind, if a context_set or index_name is not provided, the defaults must be set manually during initialization of SRUQueryer for validation to work. This is because the explainResponse does not always include the default context set or index. If you do not know them, there are options to disable validation for SearchClauses that use defaults.
 
 #### AVAILABLE FUNCTIONS
 
-You don't need to use any functions on a SearchClause as a general user. For instance, the search_retrieve.validate() function will also run the validate() function for all included SearchClauses.
+You don't need to use any functions on a SearchClause as a general user. For instance, SRUQueryer will run the validate() function for all included SearchClauses.
 
 #### INITIALIZATION OPTIONS
 
@@ -178,23 +183,20 @@ You MUST include either:
 
 - RelationModifiers can be set for all combinations, but will only added to the final query on combinations with an operation.
 
-### SRUUtil
+<br>
+<br>
 
-`from sru_queryer import SRUUtil`
+### SRUQueryer
 
-The SRUUtil static class handles core configuration for this utility, as well as providing an interface for reading the configuration information.
+`from sru_queryer import SRUQueryer`
 
-#### AVAILABLE FUNCTIONS:
+The SRUQueryer is the most important class of this library, as it handles configuring the utitlity as well as constricting, validating, and sending requests.
 
-There are two functions that the general user would want to use:
+#### INITIALIZATION OPTIONS
 
-1. `format_available_indexes` - This function nicely formats all the indexes availabe for an SRU server, as well as their information. It then prints this information to the console, to a text file, or both. It only prints to the console by default. You can filter the indexes based on their human-readable title.
+This function configures settings (stored in an SRUConfiguration object) by reading the arguments you provide, pulling values from the SRU server, and reconciling them. Many arguments are optional and are used for improved validation of the SRU queries. Be aware that any option you specify manually will override the corresponding value returned by the explainResponse, if the explainResponse contains this value.
 
-`format_available_indexes(sru_configuration, filename: str | None = None, print_to_console: bool = True, title_filter: str | None = None)`
-
-2. `create_configuration_for_server` - This function creates an SRUConfiguration object by reading you provide as arguments to the function, pulling values found by contacting the SRU server, and reconciling them. Many arguments are optional and are used for improved validation of the SRU queries. Be aware that any option you specify manually will override the corresponding value returned by the explainResponse, if the explainResponse contains this value.
-
-Arguments for create_configuration_for_server:
+If the SRU server returns a different SRU version than you specify, the tool will use that version. If you do not provide a version, it will default to version 1.2.
 
 `server_url`
 | Mandatory | Data Type | Description |
@@ -204,7 +206,7 @@ Arguments for create_configuration_for_server:
 `sru_version`
 | Mandatory | Data Type | Description |
 | ---------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Yes, but defaults to 1.2 | string | The SRU version to use.|
+| No - defaults to 1.2 | string | The SRU version to use. If the SRU server returns a different SRU version than you specify, the tool will use that version. If you do not provide a version, it will default to version 1.2. |
 
 `username`
 | Mandatory | Data Type | Description |
@@ -244,7 +246,7 @@ Arguments for create_configuration_for_server:
 `default_records_returned`
 | Mandatory | Data Type | Description |
 | ---------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| No | int | This indicates the default maximum number of records that the searchRetrieve will return. It must be equal to or less than the max_records_supported. If set, every query will return a maximum of this number of records. By default, it is set to whatever SRUUtil finds in the explainResponse OR, if not specified in the explainResponse, will not be included. |
+| No | int | This indicates the default maximum number of records that the searchRetrieve will return. It must be equal to or less than the max_records_supported. If set, every query will return a maximum of this number of records. By default, it is set to whatever is in the explainResponse OR, if not specified in the explainResponse, will not be included. |
 
 `default_record_schema`
 | Mandatory | Data Type | Description |
@@ -255,6 +257,65 @@ Arguments for create_configuration_for_server:
 | Mandatory | Data Type | Description |
 | ---------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | No | string | The default schema that sort operations are run on. I don't know too much about this. I use it for validating sortKeys, which are only for version 1.1. If the sort schema is not included in a sort key, this value will be used to validate the sort key (not all schemas can sort).|
+
+#### AVAILABLE FUNCTIONS:
+
+There are three functions that the general user would want to use:
+
+##### `search_retrieve` - This function sends a search retrieve request, using the values you provide and the information parsed from the SRU ExplainResponse.
+
+SearchRetrieve only deals with one specific query. It takes an instance of SRUConfiguration for the purposes of validation.
+
+##### USAGE
+
+After initializing your SRUQueryer class: <br>
+`response_content = queryer.search_retrieve(OR(SearchClause("alma", "title", "=", "Harry"), SearchClause("alma", "title", "=", "Potter")), record_schema="marcxml")`
+
+There are additional options to you can set to modify the request. They will be discussed below.
+
+This will validate and send the request. You will receive whatever content the SRU server sends back - it may be a searchRetrieveResponse, or it might be an error. This library does not currently validate or parse the response.
+
+##### INPUT PARAMETERS
+
+| Option          | Data Type                                                       | Mandatory | Description                                                                                                                                                                                                                                                           |
+| --------------- | --------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cql_query       | SearchClause, class extending CQLBooleanOperatorBase, or RawCQL | Yes       | The CQL query you wish to execute.                                                                                                                                                                                                                                    |
+| start_record    | int                                                             | No        | An offset - Every search produces a set on the server, but not all will be returned. This determines the first record in that set that will be returned (offset).                                                                                                     |
+| maximum_records | int                                                             | No        | Set maximum amount of records that will be returned. The default for this, if not included, can be set through SRUQueryer initialization.create_configuration_for_server, by the explainResponse, or is set to 5.                                                     |
+| record_schema   | string                                                          | No        | The format in which the searchRetrieveRessponse will return records. Default is 'marcxml.' Any value set here will be validated against the available record schemas listed in the explainResponse. REQUIRED if the default is not returned with the explainResponse. |
+| sort_queries    | list[dict] or list[SortKey]                                     | No        | A list of sortBy dictionaries, which add sort clauses to the dictionary. See below for more information.                                                                                                                                                              |
+| record_packing  | string                                                          | No        | The record packing that the record will be returned in (either xml or string)                                                                                                                                                                                         |
+
+<br>
+
+##### `construct_search_retrieve_request` - This does the same thing as the previous function, however instead of running request.prepare() and sending the request, it returns the request. This allows you to be more flexible - for instance, if you want to use a shared requests.Session between multiple requests, or add a custom authentication header.
+
+##### USAGE
+
+After initializing your SRUQueryer class: <br>
+`request = queryer.construct_search_retrieve_request(OR(SearchClause("alma", "title", "=", "Harry"), SearchClause("alma", "title", "=", "Potter")), record_schema="marcxml")`
+
+This will validate the request and return a requests.Request object.
+
+##### INPUT PARAMETERS
+
+| Option          | Data Type                                                       | Mandatory | Description                                                                                                                                                                                                                                                           |
+| --------------- | --------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cql_query       | SearchClause, class extending CQLBooleanOperatorBase, or RawCQL | Yes       | The CQL query you wish to execute.                                                                                                                                                                                                                                    |
+| start_record    | int                                                             | No        | An offset - Every search produces a set on the server, but not all will be returned. This determines the first record in that set that will be returned (offset).                                                                                                     |
+| maximum_records | int                                                             | No        | Set maximum amount of records that will be returned. The default for this, if not included, can be set through SRUQueryer initialization.create_configuration_for_server, by the explainResponse, or is set to 5.                                                     |
+| record_schema   | string                                                          | No        | The format in which the searchRetrieveRessponse will return records. Default is 'marcxml.' Any value set here will be validated against the available record schemas listed in the explainResponse. REQUIRED if the default is not returned with the explainResponse. |
+| sort_queries    | list[dict] or list[SortKey]                                     | No        | A list of sortBy dictionaries, which add sort clauses to the dictionary. See below for more information.                                                                                                                                                              |
+| record_packing  | string                                                          | No        | The record packing that the record will be returned in (either xml or string)                                                                                                                                                                                         |
+
+##### `format_available_indexes`
+
+This function nicely formats all the indexes availabe for an SRU server, as well as their information. It then prints this information to the console, to a text file, or both. It only prints to the console by default. You can filter the indexes based on their human-readable title.
+
+`format_available_indexes(sru_configuration, filename: str | None = None, print_to_console: bool = True, title_filter: str | None = None)`
+
+<br>
+<br>
 
 ### Constructing more advanced queries: Boolean Operators
 
@@ -289,7 +350,7 @@ You may add modifiers to the Boolean Operator with the 'modifiers' keyword argum
 
 #### AVAILABLE FUNCTIONS
 
-As with the SearchClause, the functions on the CQL Boolean Operators are not indended to be used by the general person. For example, Query.construct_request() will call format() for all boolean operators.
+As with the SearchClause, the functions on the CQL Boolean Operators are not indended to be used by the general person. For example, SRUQueryer.search_retrieve will call format() for all boolean operators.
 
 #### INITIALIZATION OPTIONS
 
@@ -302,52 +363,8 @@ Any options not marked as MANDATORY are optional. It is not recommended to chang
 
 Note: RawCQL classes may work in place of modifiers, however, this has not been tested.
 
-### SearchRetrieve class
-
-`from sru_queryer import SearchRetrieve`
-
-Now, for the class which you'll likely use the most - the SearchRetrieve class. Whereas SRUUtil deals with configuration, SearchRetrieve only deals with one specific query. It takes an instance of SRUConfiguration for the purposes of validation.
-
-#### USAGE
-
-Use the SearchRetrieve class to construct your request.
-Instantiate the SRUUtil class:
-`configuration = SRUUtil.construct_configuration_for_server(...)`
-Create the query class with the desired request:
-`search_retrieve_request = SearchRetrieve(configuration, OR(SearchClause("alma", "title", "=", "Harry"), SearchClause("alma", "title", "=", "Potter")), record_schema="marcxml")`
-
-There are additional options to you can set to modify the request. They will be discussed below.
-
-You can then validate the request with the validate() function, which will throw an error for the first issue it finds:
-`search_retrieve_request.validate()`
-
-After this, you can get a PreparedRequest and send it:
-`from requests import Session`
-`request_to_send = search_retrieve_request.construct_request()`
-`s = Session()`
-`response = s.send(request_to_send)`
-
-This will return an XML response, which might be a searchRetrieve response, or might be an error.
-
-#### AVAILABLE FUNCTIONS
-
-validate: Validates all components of the searchRetrieve request that can be validated. For the query itself, this is a recursive function that validates all CQLBooleanOperators / SearchClauses and their children. It will throw a ValueError an error for the first issue it finds. It returns nothing when successful.
-
-construct_request: Uses all components of the query to construct a searchRetrieve request. It pulls some of the information from the SRUConfiguration, including the base URL, username, password, and version, as well as other defaults that have been specified. Returns a requests.PreparedRequest object.
-
-#### INITIALIZATION OPTIONS
-
-Unlike many other classes, it is safe to modify variables after instantiating. This is because no validation occurs in the constructor. If you do change something, you'd just have to remember to run validate() again.
-
-| Option            | Data Type                                                       | Mandatory | Description                                                                                                                                                                                                                                                           |
-| ----------------- | --------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| sru_configuration | SRUConfiguration                                                | Yes       | The configuration of the SRU server, which is used to construct and validate queries. Create a configuration with SRUUtil's create_configuration_for_server()                                                                                                         |
-| cql_query         | SearchClause, class extending CQLBooleanOperatorBase, or RawCQL | Yes       | The CQL query you wish to execute.                                                                                                                                                                                                                                    |
-| start_record      | int                                                             | No        | An offset - Every search produces a set on the server, but not all will be returned. This determines the first record in that set that will be returned (offset).                                                                                                     |
-| maximum_records   | int                                                             | No        | Set maximum amount of records that will be returned. The default for this, if not included, can be set through SRUUtil.create_configuration_for_server, by the explainResponse, or is set to 5.                                                                       |
-| record_schema     | string                                                          | No        | The format in which the searchRetrieveRessponse will return records. Default is 'marcxml.' Any value set here will be validated against the available record schemas listed in the explainResponse. REQUIRED if the default is not returned with the explainResponse. |
-| sort_queries      | list[dict] or list[SortKey]                                     | No        | A list of sortBy dictionaries, which add sort clauses to the dictionary. See below for more information.                                                                                                                                                              |
-| record_packing    | string                                                          | No        | The record packing that the record will be returned in (either xml or string)                                                                                                                                                                                         |
+<br>
+<br>
 
 ### Custom queries: RawCQL
 
@@ -359,7 +376,7 @@ RawCQL is intended for cases in which this library does not support a certain SR
 
 Using raw cql allows you to insert whatever search condition you need, while still validating the rest of the query. You can use a RawCQL class to replace the entire search query, replace a boolean conditional, or replace a SearchClause.
 
-You don't have to worry about creating the string in exact URL notation (e.g., replacing ' ' with %20 or '"' with %22). Characters will be encoded automatically by Query.construct_request().
+You don't have to worry about creating the string in exact URL notation (e.g., replacing ' ' with %20 or '"' with %22). Characters will be encoded automatically by SRUQueryer.search_retrieve().
 
 #### USAGE
 
@@ -388,6 +405,9 @@ There's nothing here that you would want to use. This class is essentially a wra
 | raw_cql_string | string (should be CQL) | Yes       | A CQL query as a string. Again, you don't have to provide it in a url-exact format, spaces and other special characters will be replaced by their compability characters later on if you're using the provided tools. |
 | add_padding    | boolean                | No        | Whether or not to add a space (%20) before and after the string upon formatting. Set to false by default.                                                                                                             |
 
+<br>
+<br>
+
 ### Modifiying operators - Modifiers
 
 Modifiers are conditions which modify the search query operators (AND, "all", OR, etc). As indicated above, in version 1.2, they can either modify SearchClause operators or Boolean Operators.
@@ -395,9 +415,9 @@ Modifiers are conditions which modify the search query operators (AND, "all", OR
 Each modifier is preceeded by a '/' and optional spacing. One or many modifiers may be included. Modifiers must include a base_name, but MAY include a context_set, operator, and value.
 
 From the LOC website, a modifier on a Boolean Operator looks like: `dc.title any fish or/rel.combine=sum dc.creator any sanderson`.
-A modifier on a SearchClause looks like `any /relevant /cql.string`
+A modifier on a SearchClause relation looks like `any /relevant /cql.string`
 
-One thought of interest - it may be possible to include a RawCQL instead of a modifier for custom modifiers / modifier formats not available through this program. I've not tested it, but it's likely to work.
+One thought of interest - it may be possible to include a RawCQL instead of a modifier if you want to create custom modifiers or modifier formats not available through this program. I've not tested it, but it's likely to work.
 
 #### USAGE
 
@@ -438,6 +458,9 @@ You MUST include either:
 3. a base_name, operation, and value,
 4. a context_set, base_name, operation, and value.
 
+<br>
+<br>
+
 ### Sorting in 1.2: SortBy clauses
 
 sortBy clauses are simply Python dictionaries with the form:
@@ -447,15 +470,18 @@ Which will be formatted to:
 
 All values are required. The sort_order can either be "ascending" or "descending."
 
-You should add all desired sortBy clauses to the SearchRetrieve object in an array with the keyword argument 'sort_queries='
+You should add all desired sortBy clauses to the SRUQueryer.search_retrieve or SRUQueryer.construct_search_retrieve_request in an array with the keyword argument 'sort_queries='
+
+<br>
+<br>
 
 ### Sorting in 1.1: SortKey
 
 `from sru_queryer.sru import SortKey`
 
-SortKeys are used to sort results returned by a searchRetrieve request ins SRU version 1.1. SRU 1.1 doesn't specify whether sorting is allow per-index like 1.2 does; rather, it specifies this per record schema.
+SortKeys are used to sort results returned by a searchRetrieve request in SRU version 1.1. SRU 1.1 doesn't specify whether sorting is allow per-index like 1.2 does; rather, it specifies this per record schema.
 
-Note that this isn't imported from CQL. It's actually not part of the CQL query - it's another URL query string parameter.
+Note that this isn't imported from sru_queryer.cql but rather sru_queryer.sru. This is because it's actually not part of the CQL query.
 
 #### USAGE
 
@@ -463,7 +489,7 @@ Simply include a list of SortKeys in the 'sort_queries' parameter of your Search
 
 #### AVAILABLE FUNCTIONS
 
-There's nothing here that you would need to use; the built-in functions are used by other parts of the SRUUtil program.
+There's nothing here that you would need to use; the built-in functions are used by other parts of the sru_queryer library.
 
 #### INITIALIZATION OPTIONS
 

--- a/src/sru_queryer/__init__.py
+++ b/src/sru_queryer/__init__.py
@@ -1,5 +1,4 @@
-from ._base._sru_util import SRUUtil
-from ._base._search_retrieve import SearchRetrieve
+from ._base._sru_queryer import SRUQueryer
 from ._base._search_clause import SearchClause
 
-__all__ = ["SearchRetrieve", "SRUUtil", "SearchClause"]
+__all__ = ["SRUQueryer", "SearchClause"]

--- a/src/sru_queryer/_base/_search_retrieve.py
+++ b/src/sru_queryer/_base/_search_retrieve.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from requests import Request, PreparedRequest
+from requests import Request
 
 from ._search_clause import SearchClause
 from ._raw_cql import RawCQL
@@ -38,15 +38,16 @@ class SearchRetrieve:
 
         SRUValidator.validate_sort(self.sru_configuration, self.sort_queries, self.record_schema)
 
-    def construct_request(self) -> PreparedRequest:
+    def construct_request(self) -> Request:
         """Constructs the searchRetrieve request.
 
         Constructs the searchRetrieve request, including the base request, CQL query, and sortBy.
 
-        If you added a username and password when initializing the SRUUtil, it will be added to the
+        If you added a username and password when initializing SRUQueryer, it will be added to the
         headers of the request using the 'Basic access authentication' protocol.
 
-        Returns a PreparedRequest object. You can execute it using an instance of requests.Session:\n
+        Returns a Request object. You can execute it using an instance of requests.Session:\n
+            request = request.prepare()\n
             s = requests.Session()\n
             response = s.send(request)\n"""
         search_retrieve_query = SRUAuxiliaryFormatter.format_base_search_retrieve_query(self.sru_configuration,
@@ -63,7 +64,5 @@ class SearchRetrieve:
         request = Request("GET", search_retrieve_query)
         if self.sru_configuration.username and self.sru_configuration.password:
             request.headers["Authorization"] = SRUAuxiliaryFormatter.format_basic_access_authentication_header_payload(self.sru_configuration.username, self.sru_configuration.password)
-
-        request = request.prepare()
 
         return request

--- a/src/sru_queryer/sru.py
+++ b/src/sru_queryer/sru.py
@@ -1,6 +1,5 @@
-from ._base._search_retrieve import SearchRetrieve
 from ._base._sort_key import SortKey
 from ._base._sru_configuration import SRUConfiguration
-from ._base._sru_util import SRUUtil
+from ._base._sru_queryer import SRUQueryer
 
-__all__ = ["SearchRetrieve", "SortKey", "SRUConfiguration", "SRUUtil"]
+__all__ = ["SortKey", "SRUConfiguration", "SRUQueryer"]

--- a/tests/test_cql_boolean_operators.py
+++ b/tests/test_cql_boolean_operators.py
@@ -181,7 +181,6 @@ class TestCQLBooleanOperatorClasses(unittest.TestCase):
     @patch("src.sru_queryer._base._sru_validator.SRUValidator.validate_cql")
     def test_validate_operator_pair_with_valid_index_called_twice(self, mock_validate_index_info):
 
-        # Initialize the SRUUtil class
         sru_configuration = get_alma_sru_configuration()
 
         AND(SearchClause("alma", "valid_index", "==", "10"), SearchClause(

--- a/tests/test_search_retrieve.py
+++ b/tests/test_search_retrieve.py
@@ -2,15 +2,15 @@ from unittest.mock import patch
 import unittest
 from requests import Request
 
-from src.sru_queryer import SearchRetrieve
-from src.sru_queryer.sru import SRUUtil
+from src.sru_queryer._base._search_retrieve import SearchRetrieve
+from src.sru_queryer import SRUQueryer
 from src.sru_queryer.cql import SearchClause
 from src.sru_queryer.cql import AND, RawCQL
 from src.sru_queryer.sru import SortKey
 from tests.testData.test_data import TestFiles, get_alma_sru_configuration
 
 
-class TestSRUQuery(unittest.TestCase):
+class TestSearchRetrieve(unittest.TestCase):
 
     def test_construct_request(self):
         sru_configuration = get_alma_sru_configuration()
@@ -21,7 +21,7 @@ class TestSRUQuery(unittest.TestCase):
         constructed_search_retrieve_request = SearchRetrieve(sru_configuration, SearchClause("alma", "bib_holding_count", "==", "10"), record_schema="marcxml").construct_request()
 
         expected_request = Request(
-            "GET", f'https://example.com?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count==%2210%22').prepare()
+            "GET", f'https://example.com?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count=="10"')
 
         self.assertEqual(
             constructed_search_retrieve_request.method, expected_request.method)
@@ -43,7 +43,7 @@ class TestSRUQuery(unittest.TestCase):
         )).construct_request()
 
         expected_request = Request(
-            "GET", f'https://example.com/?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count%3E%2215%22%20and%20rec.mms_id==%22112233%22').prepare()
+            "GET", f'https://example.com?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count>"15"%20and%20rec.mms_id=="112233"')
 
         self.assertEqual(
             constructed_search_retrieve_request.method, expected_request.method)
@@ -67,7 +67,7 @@ class TestSRUQuery(unittest.TestCase):
 
         credentials_encoded = "dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ="
         expected_request = Request(
-            "GET", f'https://example.com/?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count%3E%2215%22%20and%20rec.mms_id==%22112233%22', headers={
+            "GET", f'https://example.com?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count>"15"%20and%20rec.mms_id=="112233"', headers={
                 "Authorization": f'Basic {credentials_encoded}'
             })
 
@@ -88,7 +88,7 @@ class TestSRUQuery(unittest.TestCase):
                                                     SearchClause("alma", "bib_holding_count", "==", '10'), record_schema="marcxml", sort_queries=[{"index_set": "alma", "index_name": "bib_holding_count", "sort_order": "ascending"}, {"index_set": "alma", "index_name": "title", "sort_order": "descending"}]).construct_request()
 
         expected_request = Request(
-            "GET", f'https://example.com/?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count==%2210%22%20sortBy%20alma.bib_holding_count/sort.ascending%20alma.title/sort.descending')
+            "GET", f'https://example.com?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.bib_holding_count=="10"%20sortBy%20alma.bib_holding_count/sort.ascending%20alma.title/sort.descending')
 
         self.assertEqual(
             constructed_search_retrieve_request.method, expected_request.method)
@@ -123,63 +123,63 @@ class TestSRUQuery(unittest.TestCase):
         self.assertIn("'fake_index'", ve.exception.__str__())
                 
 class TestQueryWithXMLData(unittest.TestCase):
-    @patch("src.sru_queryer._base._sru_util.requests.get")
+    @patch("src.sru_queryer._base._sru_queryer.requests.get")
     def test_construct_request_gapines_data_default_schema_returned_by_explain(self, mock_get):
         """Integration"""
         with open(TestFiles.explain_response_gapines, "rb") as f:
             mock_get.return_value.content = f.read()
 
             # Initialize the gapines configuration
-            sru_configuration = SRUUtil.create_configuration_for_server("https://example.com")
+            sru_configuration = SRUQueryer("https://example.com").sru_configuration
 
             constructed_search_retrieve_request = SearchRetrieve(sru_configuration, SearchClause("alma", "bib_holding_count", "==", "10")).construct_request()
 
             expected_request = Request(
-                "GET", f'https://example.com?version=1.1&operation=searchRetrieve&recordSchema=marcxml&maximumRecords=10&query=alma.bib_holding_count==%2210%22').prepare()
+                "GET", f'https://example.com?version=1.1&operation=searchRetrieve&recordSchema=marcxml&maximumRecords=10&query=alma.bib_holding_count=="10"')
             
             self.assertEqual(
                 constructed_search_retrieve_request.url, expected_request.url)
             
-    @patch("src.sru_queryer._base._sru_util.requests.get")
+    @patch("src.sru_queryer._base._sru_queryer.requests.get")
     def test_initialize_1_2_query_with_invalid_sort_type_raises_error(self, mock_get):
          with open(TestFiles.explain_response_alma, "rb") as f:
             mock_get.return_value.content = f.read()
 
             with self.assertRaises(ValueError) as ve:
-                sru_configuration = SRUUtil.create_configuration_for_server("https://example.com")
+                sru_configuration = SRUQueryer("https://example.com").sru_configuration
                 SearchRetrieve(sru_configuration, SearchClause(value="dummyval"), record_schema="marcxml", sort_queries=[SortKey("example_xpath")])
 
             self.assertIn("SortKeys", ve.exception.__str__())
             self.assertIn("1.2", ve.exception.__str__())
 
-    @patch("src.sru_queryer._base._sru_util.requests.get")
+    @patch("src.sru_queryer._base._sru_queryer.requests.get")
     def test_initialize_1_1_query_with_invalid_sort_type_raises_error(self, mock_get):
         with open(TestFiles.explain_response_gapines, "rb") as f:
             mock_get.return_value.content = f.read()
 
             with self.assertRaises(ValueError) as ve:
-                sru_configuration = SRUUtil.create_configuration_for_server("https://example.com")
+                sru_configuration = SRUQueryer("https://example.com").sru_configuration
                 SearchRetrieve(sru_configuration, SearchClause(value="dummyval"), sort_queries=[{"index_set": "alma", "index_name": "bib_holding_count", "sort_order": "ascending"}])
             
             self.assertIn("SortKeys", ve.exception.__str__())
             self.assertIn("1.1", ve.exception.__str__())
 
-    @patch('src.sru_queryer._base._sru_util.requests.get')
+    @patch('src.sru_queryer._base._sru_queryer.requests.get')
     def test_initialize_and_format_base_query_no_schema_no_error(self, mock_get):
         """Integration"""
         with open(TestFiles.explain_response_loc, "rb") as f:
             mock_get.return_value.content = f.read()
 
-            sru_configuration = SRUUtil.create_configuration_for_server("https://example.com")
+            sru_configuration = SRUQueryer("https://example.com").sru_configuration
 
             SearchRetrieve(sru_configuration, RawCQL("pass")).validate()
     
-    @patch('src.sru_queryer._base._sru_util.requests.get')
+    @patch('src.sru_queryer._base._sru_queryer.requests.get')
     def test_initialize_query_default_schema_raises_no_error(self, mock_get):
         """Integration"""
         with open(TestFiles.explain_response_gapines, "rb") as f:
             mock_get.return_value.content = f.read() 
 
-            sru_configuration = SRUUtil.create_configuration_for_server("https://example.com")
+            sru_configuration = SRUQueryer("https://example.com").sru_configuration
 
             SearchRetrieve(sru_configuration, RawCQL("pass"))

--- a/tests/test_sru_queryer.py
+++ b/tests/test_sru_queryer.py
@@ -1,32 +1,32 @@
 import unittest
 from unittest.mock import patch
 
-from src.sru_queryer.sru import SRUUtil
+from src.sru_queryer import SRUQueryer
 from src.sru_queryer._base._exceptions import ExplainResponseContentTypeException
 from tests.testData.test_data import get_alma_sru_configuration, get_gapines_sru_configuration, mock_searchable_indexes_and_descriptions, TestFiles
 
-@patch("src.sru_queryer.sru.SRUUtil._retrieve_explain_response_xml")
-@patch("src.sru_queryer.sru.SRUUtil._parse_explain_response_configuration")
-class TestSRUUtilCreateConfiguration(unittest.TestCase):
+@patch("src.sru_queryer.SRUQueryer._retrieve_explain_response_xml")
+@patch("src.sru_queryer.SRUQueryer._parse_explain_response_configuration")
+class TestSRUQueryerInitialization(unittest.TestCase):
 
     def test_merge_config_and_user_settings_urls_set_correctly(self, mock_parse_explain_response, *args):
         mock_parse_explain_response.return_value = get_alma_sru_configuration()
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com")
+        updated_config = SRUQueryer("testurl2.com").sru_configuration
 
         self.assertEqual(updated_config.server_url, "testurl2.com")
 
     def test_merge_config_and_user_settings_version_updates_based_on_explain(self, mock_parse_explain_response, *args):
         mock_parse_explain_response.return_value = get_alma_sru_configuration()
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com", sru_version="1.1")
+        updated_config = SRUQueryer("testurl2.com", sru_version="1.1").sru_configuration
 
         self.assertEqual(updated_config.sru_version, "1.2")
 
     def test_merge_config_and_user_settings_set_record_numbers_returned_correctly(self, mock_parse_explain_response, *args):
         mock_parse_explain_response.return_value = get_alma_sru_configuration()
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com", default_records_returned=15, max_records_supported=40)
+        updated_config = SRUQueryer("testurl2.com", default_records_returned=15, max_records_supported=40).sru_configuration
 
         self.assertEqual(updated_config.default_records_returned, 15)
         self.assertEqual(updated_config.max_records_supported, 40)
@@ -34,7 +34,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
     def test_merge_config_and_user_settings_set_username_password_returned_correctly(self, mock_parse_explain_response, *args):
         mock_parse_explain_response.return_value = get_alma_sru_configuration()
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com", username="testusername", password="testpassword")
+        updated_config = SRUQueryer("testurl2.com", username="testusername", password="testpassword").sru_configuration
 
         self.assertEqual(updated_config.username, "testusername")
         self.assertEqual(updated_config.password, "testpassword")
@@ -42,7 +42,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
     def test_merge_config_and_user_settings_set_cql_defaults_returned_correctly(self, mock_parse_explain_response, *args):
         mock_parse_explain_response.return_value = get_alma_sru_configuration()
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com", default_cql_context_set="alma", default_cql_index="all_for_ui", default_cql_relation="all")
+        updated_config = SRUQueryer("testurl2.com", default_cql_context_set="alma", default_cql_index="all_for_ui", default_cql_relation="all").sru_configuration
 
         self.assertEqual(updated_config.default_context_set, "alma")
         self.assertEqual(updated_config.default_index, "all_for_ui")
@@ -51,7 +51,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
     def test_merge_config_and_user_settings_set_default_schemas_returned_correctly(self, mock_parse_explain_response, *args):
         mock_parse_explain_response.return_value = get_alma_sru_configuration()
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com", default_record_schema="marcxml", default_sort_schema="marcxml")
+        updated_config = SRUQueryer("testurl2.com", default_record_schema="marcxml", default_sort_schema="marcxml").sru_configuration
 
         self.assertEqual(updated_config.default_record_schema, "marcxml")
         self.assertEqual(updated_config.default_sort_schema, "marcxml")
@@ -59,7 +59,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
     def test_merge_config_and_user_settings_set_disable_validation_for_cql_defaults_returned_correctly(self, mock_parse_explain_response, *args):
         mock_parse_explain_response.return_value = get_alma_sru_configuration()
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com", disable_validation_for_cql_defaults=True)
+        updated_config = SRUQueryer("testurl2.com", disable_validation_for_cql_defaults=True).sru_configuration
 
         self.assertEqual(updated_config.disable_validation_for_cql_defaults, True)
 
@@ -67,7 +67,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
         configuration_parsed_from_explain_response = get_gapines_sru_configuration()
         mock_parse_explain_response.return_value = configuration_parsed_from_explain_response
 
-        updated_config = SRUUtil.create_configuration_for_server("testurl2.com")
+        updated_config = SRUQueryer("testurl2.com").sru_configuration
 
         self.assertEqual(updated_config.disable_validation_for_cql_defaults, False)
         self.assertEqual(updated_config.default_context_set, "eg")
@@ -98,7 +98,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
 
 
     def test_filter_available_context_sets_and_indexes_different_capitalization(self, *args):
-        filtered_dict = SRUUtil._filter_available_context_sets_and_indexes(
+        filtered_dict = SRUQueryer._filter_available_context_sets_and_indexes(
             mock_searchable_indexes_and_descriptions, title="library")
 
         self.assertDictEqual(filtered_dict, {
@@ -121,7 +121,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
         })
 
     def test_filter_available_context_sets_and_indexes_different_set(self, *args):
-        filtered_dict = SRUUtil._filter_available_context_sets_and_indexes(
+        filtered_dict = SRUQueryer._filter_available_context_sets_and_indexes(
             mock_searchable_indexes_and_descriptions, title="mms")
         
         expected_index = self.create_index_config("Bib MMS ID", None, False, ["==", "all"], True)
@@ -130,7 +130,7 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
 
 
     def test_filter_available_context_sets_and_indexes_two_sets(self, *args):
-        filtered_dict = SRUUtil._filter_available_context_sets_and_indexes(
+        filtered_dict = SRUQueryer._filter_available_context_sets_and_indexes(
             mock_searchable_indexes_and_descriptions, title="bib")
 
         self.assertDictEqual(filtered_dict, {
@@ -154,14 +154,14 @@ class TestSRUUtilCreateConfiguration(unittest.TestCase):
             },
         })
 
-class TestSRUUtilExplainResponseXMLParse(unittest.TestCase):
+class TestSRUQUeryerExplainResponseXMLParse(unittest.TestCase):
 
-    @patch("src.sru_queryer.sru.SRUUtil._get_request_contents")
+    @patch("src.sru_queryer.SRUQueryer._get_request_contents")
     def test_parse_html_raises_parser_failure_exception(self, mock_request_contents):
         with open(TestFiles.gapines_html_response, "rb") as f:
             mock_request_contents.return_value = f.read()
 
         with self.assertRaises(ExplainResponseContentTypeException) as pe:
-            SRUUtil._retrieve_explain_response_xml("blahblah", None, None)
+            SRUQueryer._retrieve_explain_response_xml("blahblah", None, None)
         
         print(pe.exception)


### PR DESCRIPTION
Before, the public interface for this library required importing
SRUUtil, creating an SRUConfiguration object, creating a Query
object, constructing the request, creating a session with
requests.session, sending the request, and parsing the response.
This is a cumbersome process.

I've refactored the application so that you simply have to
create an SRUQueryer with a server URL, and can then run
the search_retrieve() function directly on the queryer which
will return the content.

This will be a part of 2.0.0, and its what the interface
should have been to start with.