### PR TITLE
Refactored available schemas, fixed default validation.

### DIFF
--- a/src/sru_queryer/_base/_search_retrieve.py
+++ b/src/sru_queryer/_base/_search_retrieve.py
@@ -31,6 +31,8 @@ class SearchRetrieve:
         """Validates the searchRetrieve request. 
         Keep in mind that not all facets of the request are validated."""
 
+        SRUValidator.validate_defaults(self.sru_configuration)
+
         SRUValidator.validate_base_query(self.sru_configuration,
             self.start_record, self.maximum_records, self.record_schema, self.record_packing)
 
@@ -53,9 +55,10 @@ class SearchRetrieve:
         search_retrieve_query = SRUAuxiliaryFormatter.format_base_search_retrieve_query(self.sru_configuration,
             self.start_record, self.maximum_records, self.record_schema, self.record_packing)
 
-        if isinstance(self.cql_query, SearchClause) and not (self.cql_query.get_index_name() and self.cql_query.get_relation()):
-            # If it's just a single value (search term) as the query, without anything else, append an equals sign.
-            search_retrieve_query += "="
+        # if isinstance(self.cql_query, SearchClause) and not (self.cql_query.get_index_name() and self.cql_query.get_relation()):
+        #     # If it's just a single value (search term) as the query, without anything else, append an equals sign.
+        #     search_retrieve_query += "="
+        # This ^ caused the query to fail. I'm not sure why I put it here, but I'm leaving it here just in case.
         search_retrieve_query += self.cql_query.format()
 
         search_retrieve_query += SRUAuxiliaryFormatter.format_sort_query(self.sort_queries)

--- a/src/sru_queryer/_base/_sru_explain_auto_parser.py
+++ b/src/sru_queryer/_base/_sru_explain_auto_parser.py
@@ -167,22 +167,12 @@ class SRUExplainAutoParser():
                 sort = False
 
             schema_name = schema["@name"]
-            # The schema identifier can be used in place of the
-            # name in a query
-            alternate_schema_name = None
-            try: 
-                alternate_schema_name = schema["@identifier"]
-            except:
-                pass
+            schema_identifier = schema["@identifier"]
 
             cleaned_record_schema_info[schema_name] = {
-                "sort": sort
+                "sort": sort,
+                "identifier": schema_identifier
             }
-
-            if alternate_schema_name:
-                cleaned_record_schema_info[alternate_schema_name] = {
-                    "sort": sort
-                }
         
         self.sru_config.available_record_schemas = cleaned_record_schema_info
 

--- a/src/sru_queryer/_base/_sru_queryer.py
+++ b/src/sru_queryer/_base/_sru_queryer.py
@@ -57,6 +57,11 @@ class SRUQueryer():
         if not sru_version:
             logging.info(f"Using SRU version {configuration.sru_version}")
 
+        # If there is not a default cql relation returned by the server, set it to '=' (this is the default from the LOC standards)
+        # This will later be overridden if the user chooses a value.
+        if not configuration.default_relation:
+            configuration.default_relation = '='
+
         configuration.server_url = server_url
         configuration.username = username
         configuration.password = password
@@ -64,31 +69,31 @@ class SRUQueryer():
 
         # Override SRUExplain values / set if not provided
         if default_records_returned:
-            if configuration.default_records_returned and (configuration.default_records_returned != default_records_returned): logging.info(f"Overriding default number of records returned (Set {default_records_returned}, server specified {configuration.default_records_returned}).")
+            if configuration.default_records_returned and (configuration.default_records_returned != default_records_returned): logging.info(f"Overriding default number of records returned (Using {default_records_returned}, server specified {configuration.default_records_returned}).")
             configuration.default_records_returned = default_records_returned
 
         if max_records_supported:
-            if configuration.max_records_supported and (configuration.max_records_supported != max_records_supported): logging.warning(f"Overriding max records supported (Set {max_records_supported}, server specified {configuration.max_records_supported}).")
+            if configuration.max_records_supported and (configuration.max_records_supported != max_records_supported): logging.warning(f"Overriding max records supported (Using {max_records_supported}, server specified {configuration.max_records_supported}).")
             configuration.max_records_supported = max_records_supported
 
         if default_cql_context_set:
-            if configuration.default_context_set and (configuration.default_context_set != default_cql_context_set): logging.warning(f"Overriding default context set (Set {default_cql_context_set}, server specified {configuration.default_context_set}).")
+            if configuration.default_context_set and (configuration.default_context_set != default_cql_context_set): logging.warning(f"Overriding default context set (Using {default_cql_context_set}, server specified {configuration.default_context_set}).")
             configuration.default_context_set = default_cql_context_set
 
         if default_cql_index:
-            if configuration.default_index and (configuration.default_index != default_cql_index): logging.warning(f"Overriding default index (Set {default_cql_index}, server specified {configuration.default_index}).")
+            if configuration.default_index and (configuration.default_index != default_cql_index): logging.warning(f"Overriding default index (Using {default_cql_index}, server specified {configuration.default_index}).")
             configuration.default_index = default_cql_index
 
         if default_cql_relation:
-            if configuration.default_relation and (configuration.default_relation != default_cql_relation): logging.warning(f"Overriding default CQL relation (Set {default_cql_relation}, server specified {configuration.default_relation}).")
+            if configuration.default_relation and (configuration.default_relation != default_cql_relation): logging.warning(f"Overriding default CQL relation (Using {default_cql_relation}, server specified {configuration.default_relation}).")
             configuration.default_relation = default_cql_relation
 
         if default_record_schema:
-            if configuration.default_record_schema and (configuration.default_record_schema != default_record_schema): logging.info(f"Overriding default record schema (Set {default_record_schema}, server specified {configuration.default_record_schema}).")
+            if configuration.default_record_schema and (configuration.default_record_schema != default_record_schema): logging.info(f"Overriding server specified record schema (Using {default_record_schema}, server specified {configuration.default_record_schema}).")
             configuration.default_record_schema = default_record_schema
 
         if default_sort_schema:
-            if configuration.default_sort_schema and (configuration.default_sort_schema != default_sort_schema): logging.warning(f"Overriding default sort schema (Set {default_sort_schema}, server specified {configuration.default_sort_schema}).")
+            if configuration.default_sort_schema and (configuration.default_sort_schema != default_sort_schema): logging.warning(f"Overriding default sort schema (Using {default_sort_schema}, server specified {configuration.default_sort_schema}).")
             configuration.default_sort_schema = default_sort_schema
 
         self.sru_configuration = configuration
@@ -102,6 +107,7 @@ class SRUQueryer():
         query = SearchRetrieve(self.sru_configuration, cql_query, start_record, maximum_records, record_schema, sort_queries, record_packing)
         query.validate()
         request = query.construct_request()
+        logging.info(f"Querying {request.url}")
         request = request.prepare()
         s = requests.Session()
         response = s.send(request)

--- a/tests/testData/test_data.py
+++ b/tests/testData/test_data.py
@@ -112,40 +112,56 @@ mock_searchable_indexes_and_descriptions_loc_data = {
 
 test_available_record_schemas = {
     "marcxml": {
-       "sort": True
+        "identifier": "http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd",
+        "sort": True
     }, "dc": {
+       "identifier": "info:srw/schema/1/dc-v1.1",
        "sort": True
     }, "mods": {
+       "identifier": "info:srw/schema/1/mods-v3.5",
        "sort": True
     }, "dcx": {
+       "identifier": "info:srw/schema/1/dcx-v1.0",
        "sort": True
     }, "unimarcxml": {
+       "identifier": "info:srw/schema/8/unimarcxml-v0.1",
        "sort": True
     }, "kormarcxml": {
+       "identifier": "http://www.nl.go.kr/kormarc/",
        "sort": True
     }, "cnmarcxml": {
+       "identifier": "http://www.nlc.cn/",
        "sort": True
     }, "isohold": {
+       "identifier": "http://www.loc.gov/standards/iso20775/",
        "sort": True
     }
 }
 
 test_available_record_schemas_gapines = {
     "marcxml": {
-       "sort": True
+        "identifier": "http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd",
+        "sort": True
     }, "dc": {
+       "identifier": "info:srw/schema/1/dc-v1.1",
        "sort": True
     }, "mods": {
+       "identifier": "info:srw/schema/1/mods-v3.5",
        "sort": True
     }, "dcx": {
+       "identifier": "info:srw/schema/1/dcx-v1.0",
        "sort": True
     }, "unimarcxml": {
+       "identifier": "info:srw/schema/8/unimarcxml-v0.1",
        "sort": True
     }, "kormarcxml": {
+       "identifier": "http://www.nl.go.kr/kormarc/",
        "sort": True
     }, "cnmarcxml": {
+       "identifier": "http://www.nlc.cn/",
        "sort": True
     }, "isohold": {
+       "identifier": "http://www.loc.gov/standards/iso20775/",
        "sort": True
     }
 }
@@ -207,7 +223,33 @@ mock_searchable_indexes_and_descriptions = {
 }
 
 # test_available_record_schemas = {'marcxml': {'sort': True}, 'dc': {'sort': True}, 'mods': {'sort': True}, 'dcx': {'sort': True}, 'unimarcxml': {'sort': True}, 'kormarcxml': {'sort': True}, 'cnmarcxml': {'sort': True}, 'isohold': {'sort': True}}
-test_available_record_schemas_one_false = {'marcxml': {'sort': True}, 'dc': {'sort': True}, 'mods': {'sort': True}, 'dcx': {'sort': True}, 'unimarcxml': {'sort': True}, 'kormarcxml': {'sort': True}, 'cnmarcxml': {'sort': False}, 'isohold': {'sort': True}}
+test_available_record_schemas_one_false = {
+    "marcxml": {
+        "identifier": "http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd",
+        "sort": True
+    }, "dc": {
+       "identifier": "info:srw/schema/1/dc-v1.1",
+       "sort": True
+    }, "mods": {
+       "identifier": "info:srw/schema/1/mods-v3.5",
+       "sort": True
+    }, "dcx": {
+       "identifier": "info:srw/schema/1/dcx-v1.0",
+       "sort": True
+    }, "unimarcxml": {
+       "identifier": "info:srw/schema/8/unimarcxml-v0.1",
+       "sort": True
+    }, "kormarcxml": {
+       "identifier": "http://www.nl.go.kr/kormarc/",
+       "sort": True
+    }, "cnmarcxml": {
+       "identifier": "http://www.nlc.cn/",
+       "sort": False
+    }, "isohold": {
+       "identifier": "http://www.loc.gov/standards/iso20775/",
+       "sort": True
+    }
+}
 
 class MockSortKeyOne(SortKey):
   def __init__(*args, **kwargs):

--- a/tests/test_search_retrieve.py
+++ b/tests/test_search_retrieve.py
@@ -97,14 +97,27 @@ class TestSearchRetrieve(unittest.TestCase):
         self.assertEqual(
             constructed_search_retrieve_request.headers, expected_request.headers)
 
-    def test_validate_query_with_base_query_error(self):
+    def test_validate_query_with_bad_record_schema_raises_error(self):
         sru_configuration = get_alma_sru_configuration()
         sru_configuration.server_url = "https://example.com"
         sru_configuration.sru_version = "1.2"
         sru_configuration.default_records_returned = None
 
         with self.assertRaises(ValueError) as ve:
-            SearchRetrieve(sru_configuration, SearchClause("alma", "bib_holding_count", "==", "10"), record_schema='fakefake').validate()
+            SearchRetrieve(sru_configuration, SearchClause("alma", "action_note_note", "==", "10"), record_schema='fakefake').validate()
+
+        self.assertIn("'fakefake'", ve.exception.__str__())
+        self.assertIn("not available", ve.exception.__str__())
+
+    def test_validate_query_with_bad_default_record_schema_raises_error(self):
+        sru_configuration = get_alma_sru_configuration()
+        sru_configuration.server_url = "https://example.com"
+        sru_configuration.sru_version = "1.2"
+        sru_configuration.default_records_returned = None
+        sru_configuration.default_record_schema = "fakefake"
+
+        with self.assertRaises(ValueError) as ve:
+            SearchRetrieve(sru_configuration, SearchClause("alma", "action_note_note", "==", "10")).validate()
 
         self.assertIn("'fakefake'", ve.exception.__str__())
         self.assertIn("not available", ve.exception.__str__())

--- a/tests/test_sru_explain_auto_parser.py
+++ b/tests/test_sru_explain_auto_parser.py
@@ -138,12 +138,11 @@ class TestSRUExplainAutoParser(unittest.TestCase):
             sru_dict_parser = SRUExplainAutoParser(alma_dict)
             sc = sru_dict_parser.get_sru_configuration_from_explain_response()
 
-            parsed_stringified_available_record_schemas = json.dumps(sc.available_record_schemas)
-            for record_schema in test_available_record_schemas:
-                stringified_record_schema = json.dumps(record_schema)
-                self.assertTrue(stringified_record_schema in parsed_stringified_available_record_schemas)
+            for record_schema_name in test_available_record_schemas.keys():
+                self.assertTrue(record_schema_name in sc.available_record_schemas.keys(), "Parsed record schemas are missing an expected record schema.")
+                self.assertDictEqual(test_available_record_schemas[record_schema_name], sc.available_record_schemas[record_schema_name], "An expected record schema does not match an actual record schema.")
 
-            self.assertEqual(len(sc.available_record_schemas), 16)
+            self.assertEqual(len(sc.available_record_schemas), 8)
 
     def test_parse_schema_info_loc(self):
         with open(TestFiles.explain_response_loc, "rb") as f:
@@ -152,7 +151,7 @@ class TestSRUExplainAutoParser(unittest.TestCase):
             sru_dict_parser = SRUExplainAutoParser(loc_dict)
             sc = sru_dict_parser.get_sru_configuration_from_explain_response()
 
-            self.assertEqual(len(sc.available_record_schemas), 8)
+            self.assertEqual(len(sc.available_record_schemas), 4)
 
     def test_bad_explain_response_loc_raises_exception(self):
         with open(TestFiles.loc_bad_explain_response, "rb") as f:
@@ -181,10 +180,9 @@ class TestSRUExplainAutoParser(unittest.TestCase):
             # Check if each record schema is in the parsed record schemas
             # (The test_available_record_schemas are a subset of what's included in 
             # explain_response_alma)
-            parsed_stringified_available_record_schemas = json.dumps(configuration.available_record_schemas)
-            for record_schema in test_available_record_schemas:
-                stringified_record_schema = json.dumps(record_schema)
-                self.assertTrue(stringified_record_schema in parsed_stringified_available_record_schemas)
+            for record_schema_name in test_available_record_schemas.keys():
+                self.assertTrue(record_schema_name in configuration.available_record_schemas.keys(), "Parsed record schemas are missing an expected record schema.")
+                self.assertDictEqual(test_available_record_schemas[record_schema_name], configuration.available_record_schemas[record_schema_name], "An expected record schema does not match an actual record schema.")
 
             self.assertListEqual(configuration.supported_relation_modifiers, [])
             self.assertEqual(configuration.default_context_set, None)
@@ -210,7 +208,7 @@ class TestSRUExplainAutoParser(unittest.TestCase):
                 sru_dict_parser = SRUExplainAutoParser(xml_dict)
                 configuration = sru_dict_parser.get_sru_configuration_from_explain_response()
 
-                self.assertDictEqual({'marcxml': {'sort': True}, 'info:srw/schema/1/marcxml-v1.1': {'sort': True}}, configuration.available_record_schemas)
+                self.assertDictEqual({'marcxml': {'sort': True, "identifier": "info:srw/schema/1/marcxml-v1.1"}}, configuration.available_record_schemas)
                 self.assertDictEqual(configuration.available_context_sets_and_indexes, expected_indexes)
                 self.assertListEqual(configuration.supported_relation_modifiers, ["relevant", "stem", "fuzzy", "word"])
                 self.assertEqual(configuration.default_context_set, "eg")
@@ -228,9 +226,9 @@ class TestSRUExplainAutoParser(unittest.TestCase):
             sru_dict_parser = SRUExplainAutoParser(xml_dict)
             configuration = sru_dict_parser.get_sru_configuration_from_explain_response()
 
-            stringified_available_record_schemas = json.dumps(configuration.available_record_schemas)
-            self.assertTrue(json.dumps({"marcxml": {"sort": False}}).strip("{}") in stringified_available_record_schemas)
-            self.assertTrue(json.dumps({"http://www.loc.gov/MARC21/slim": {"sort": False}}).strip("{}") in stringified_available_record_schemas)
+
+            self.assertTrue("marcxml" in configuration.available_record_schemas.keys(), "Parsed record schemas are missing an expected record schema.")
+            self.assertDictEqual({"sort": False, "identifier": "http://www.loc.gov/MARC21/slim"}, configuration.available_record_schemas["marcxml"], "An expected record schema does not match an actual record schema.")
 
             self.assertListEqual(configuration.supported_relation_modifiers, [])
             self.assertEqual(configuration.default_context_set, None)

--- a/tests/test_sru_validator.py
+++ b/tests/test_sru_validator.py
@@ -1,7 +1,7 @@
 import unittest
 
 from src.sru_queryer._base._sru_validator import SRUValidator
-from tests.testData.test_data import get_gapines_sru_configuration, get_alma_sru_configuration, get_test_sru_configuration_no_sort_or_supported_relations_or_config, test_available_record_schemas_one_false
+from tests.testData.test_data import get_gapines_sru_configuration, get_alma_sru_configuration, get_test_sru_configuration_no_sort_or_supported_relations_or_config, test_available_record_schemas_one_false, test_available_record_schemas
 from src.sru_queryer.sru import SortKey
 
 class TestSRUValidator(unittest.TestCase):
@@ -187,6 +187,12 @@ class TestSRUValidator(unittest.TestCase):
             SRUValidator.validate_defaults(sru_configuration)
 
         self.assertIn("invalid_record_schema", ve.exception.__str__())
+
+    def test_validate_record_schema_using_identifier_throws_error(self):
+        with self.assertRaises(ValueError) as ve:
+            SRUValidator._validate_record_schema(test_available_record_schemas, "http://www.loc.gov/standards/iso20775/")
+
+        self.assertIn("http://www.loc.gov/standards/iso20775/", ve.exception.__str__())
 
     def test_validate_configuration_defaults_throws_error_invalid_sort_schema(self):
         sru_configuration = get_alma_sru_configuration()


### PR DESCRIPTION
I refactored the schemas available to include the identifier for each schema name, instead of including them as seperate entities. This fixed a bug I didn't know about, which is that you can't use the identifier as the schema name in the URL.

I also fixed an issue where an extra '=' sign is added in queries with only a search term. This was causing errors.

I also realized I had forgotten to add the validator for the defaults! This meant that I could set a bad record schema as the default, and it goes through just fine.

Lastly, I added the '=' sign as the default relation IF the user don't provide one and the explainResponse doesn't return it. This is because it will be difficult for the user to determine this default and it's directly stated in the documentation.