### PR TITLE
Added option to disable validation.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,6 +290,7 @@ This will validate and send the request. You will receive whatever content the S
 | record_schema   | string                                                          | No        | The format in which the searchRetrieveRessponse will return records. Default is 'marcxml.' Any value set here will be validated against the available record schemas listed in the explainResponse. REQUIRED if the default is not returned with the explainResponse. |
 | sort_queries    | list[dict] or list[SortKey]                                     | No        | A list of sortBy dictionaries, which add sort clauses to the dictionary. See below for more information.                                                                                                                                                              |
 | record_packing  | string                                                          | No        | The record packing that the record will be returned in (either xml or string)                                                                                                                                                                                         |
+| validate        | boolean (default True)                                          | No        | Whether or not to validate the query before sending it. You can disable validation if you think the library is falsely failing a query.                                                                                                                               |
 
 <br>
 
@@ -314,6 +315,7 @@ This will validate the request and return a requests.Request object.
 | record_schema   | string                                                          | No        | The format in which the searchRetrieveRessponse will return records. Default is 'marcxml.' Any value set here will be validated against the available record schemas listed in the explainResponse. REQUIRED if the default is not returned with the explainResponse. |
 | sort_queries    | list[dict] or list[SortKey]                                     | No        | A list of sortBy dictionaries, which add sort clauses to the dictionary. See below for more information.                                                                                                                                                              |
 | record_packing  | string                                                          | No        | The record packing that the record will be returned in (either xml or string)                                                                                                                                                                                         |
+| validate        | boolean (default True)                                          | No        | Whether or not to validate the query before returning the requests.Request object. You can disable validation if you think the library is falsely failing a query.                                                                                                    |
 
 ##### `format_available_indexes`
 

--- a/src/sru_queryer/_base/_sru_queryer.py
+++ b/src/sru_queryer/_base/_sru_queryer.py
@@ -98,14 +98,15 @@ class SRUQueryer():
 
         self.sru_configuration = configuration
 
-    def search_retrieve(self, cql_query: SearchClause | CQLBooleanOperatorBase | RawCQL, start_record: int | None = None, maximum_records: int | None = None, record_schema: str | None = None, sort_queries: list[dict] | list[SortKey] | None = None, record_packing: str | None = None) -> bytes:
+    def search_retrieve(self, cql_query: SearchClause | CQLBooleanOperatorBase | RawCQL, start_record: int | None = None, maximum_records: int | None = None, record_schema: str | None = None, sort_queries: list[dict] | list[SortKey] | None = None, record_packing: str | None = None, validate: bool = True) -> bytes:
         """Conducts a searchRetrieve request and returns the response.
 
         This will throw ValueErrors for any incorrect portion of the query. 
         
         This function does not handle any errors in the searchRetrieveResponse."""
         query = SearchRetrieve(self.sru_configuration, cql_query, start_record, maximum_records, record_schema, sort_queries, record_packing)
-        query.validate()
+        if validate:
+            query.validate()
         request = query.construct_request()
         logging.info(f"Querying {request.url}")
         request = request.prepare()
@@ -113,13 +114,14 @@ class SRUQueryer():
         response = s.send(request)
         return response.content
     
-    def construct_search_retrieve_request(self, cql_query: SearchClause | CQLBooleanOperatorBase | RawCQL, start_record: int | None = None, maximum_records: int | None = None, record_schema: str | None = None, sort_queries: list[dict] | list[SortKey] | None = None, record_packing: str | None = None) -> Request:
+    def construct_search_retrieve_request(self, cql_query: SearchClause | CQLBooleanOperatorBase | RawCQL, start_record: int | None = None, maximum_records: int | None = None, record_schema: str | None = None, sort_queries: list[dict] | list[SortKey] | None = None, record_packing: str | None = None, validate: bool = True) -> Request:
         """Construct a requests.Request object, which you can then prepare and use.
         
         This is helpful (as compared to search_retrieve) when you want to create a request, and perhaps modify it
         or use it with your own session mechanism."""
         query = SearchRetrieve(self.sru_configuration, cql_query, start_record, maximum_records, record_schema, sort_queries, record_packing)
-        query.validate()
+        if validate:
+            query.validate()
         return query.construct_request()
     
     def format_available_indexes(self, filename: str | None = None, print_to_console: bool = True, title_filter: str | None = None):


### PR DESCRIPTION
I added an option to disable validation when getting a request object or sending a search_retrieve query. This allows you to send or examine a searchRetrieve request that the program is marking as invalid.

This would be useful for debugging, or also disabling validation for queries that someone suspects the library is unnecessarily failing.