### PR TITLE
LIBILS-916. Allow for no Record Schema info.

### DIFF
--- a/src/sru_queryer/_base/_sru_configuration.py
+++ b/src/sru_queryer/_base/_sru_configuration.py
@@ -9,7 +9,7 @@ class SRUConfiguration():
                 # Values (possibly) pulled from SRU ExplainResponse (some can be overridden by user settings):
                 # Availability
                 self.available_context_sets_and_indexes: dict = from_dict["available_context_sets_and_indexes"]
-                self.available_record_schemas: dict = from_dict["available_record_schemas"]
+                self.available_record_schemas: dict | None = from_dict["available_record_schemas"]
                 self.supported_relation_modifiers: list[str] = from_dict["supported_relation_modifiers"]
                 # Default CQL
                 self.default_context_set: str | None = from_dict["default_context_set"]
@@ -38,7 +38,7 @@ class SRUConfiguration():
         # Values (possibly) pulled from SRU ExplainResponse (some can be overridden by user settings):
         # Availability
         self.available_context_sets_and_indexes: dict = {}
-        self.available_record_schemas: dict = {}
+        self.available_record_schemas: dict | None = None
         self.supported_relation_modifiers: list[str] = []
         # Default CQL
         self.default_context_set: str | None = None

--- a/src/sru_queryer/_base/_sru_explain_auto_parser.py
+++ b/src/sru_queryer/_base/_sru_explain_auto_parser.py
@@ -152,8 +152,13 @@ class SRUExplainAutoParser():
         While this is technically duplication, they're both valid ways to write a schema in an SRU query.
         I didn't know this until I had already defined the available_record_schemas as a simple list, and
         didn't want to rip my program apart to fix this. So, for now, the record schemas are all duplicated
-        if they have identifiers so that validation will work with those identifier names."""
+        if they have identifiers so that validation will work with those identifier names.
+        
+        This information is optional to include in an SRU response, so we are setting it to None if the
+        information cannot be found."""
         schema_information = self._find_property_value(self.sru_explain_dict, generic_driver["schema"]["location"])
+        if not schema_information: return
+        
         cleaned_record_schema_info: dict = {}
         
         # Turn dict to list so we can interate through it 

--- a/src/sru_queryer/_base/_sru_validator.py
+++ b/src/sru_queryer/_base/_sru_validator.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 from ._sru_configuration import SRUConfiguration
 from ._sort_key import SortKey
@@ -17,19 +18,21 @@ class SRUValidator():
 
         # Validate default record schema
         if sru_configuration.default_record_schema:
-            record_schema_valid = SRUValidator._validate_record_schema(sru_configuration.available_record_schemas, sru_configuration.default_record_schema)
-            if not record_schema_valid:
-                raise ValueError(f"Record schema '{sru_configuration.default_record_schema}' is not available.")
+            if sru_configuration.available_record_schemas:
+                record_schema_valid = SRUValidator._validate_record_schema(sru_configuration.available_record_schemas, sru_configuration.default_record_schema)
+                if not record_schema_valid:
+                    raise ValueError(f"Record schema '{sru_configuration.default_record_schema}' is not available.")
         
         # If there is a default sort schema, check that it exists and that it can sort
         default_sort_schema = sru_configuration.default_sort_schema
         if default_sort_schema:
-            sort_schema_valid = SRUValidator._validate_record_schema(sru_configuration.available_record_schemas, default_sort_schema)
-            if not sort_schema_valid:
-                raise ValueError(f"Sort schema '{default_sort_schema}' is not available.")
-            sort_schema_info = sru_configuration.available_record_schemas[default_sort_schema]
-            if sort_schema_info["sort"] is False:
-                raise ValueError(f"Schema {default_sort_schema} cannot sort.")
+            if sru_configuration.available_record_schemas:
+                sort_schema_valid = SRUValidator._validate_record_schema(sru_configuration.available_record_schemas, default_sort_schema)
+                if not sort_schema_valid:
+                    raise ValueError(f"Sort schema '{default_sort_schema}' is not available.")
+                sort_schema_info = sru_configuration.available_record_schemas[default_sort_schema]
+                if sort_schema_info["sort"] is False:
+                    raise ValueError(f"Schema {default_sort_schema} cannot sort.")
 
     
     @staticmethod
@@ -103,8 +106,11 @@ class SRUValidator():
                 raise ValueError(f"Maximum records returned must be less than {str(sru_configuration.max_records_supported)}.") 
         
         if record_schema:
-            if SRUValidator._validate_record_schema(sru_configuration.available_record_schemas, record_schema) == False:
-                raise ValueError(f"Record schema '{record_schema}' is not available.")
+            if sru_configuration.available_record_schemas:
+                if SRUValidator._validate_record_schema(sru_configuration.available_record_schemas, record_schema) == False:
+                    raise ValueError(f"Record schema '{record_schema}' is not available.")
+            else:
+                logging.warning("Record schema cannot be validated because the SRU Explain Response does not contain this information.")
             
         if record_packing:
             if record_packing not in sru_configuration.available_record_packing_values:

--- a/tests/testData/sru_no_schema.xml
+++ b/tests/testData/sru_no_schema.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<zs:explainResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:record><zs:recordSchema>http://explain.z3950.org/dtd/2.0/</zs:recordSchema><zs:recordPacking>xml</zs:recordPacking><zs:recordData><explain xmlns="http://explain.z3950.org/dtd/2.0/">
+      <serverInfo>
+        <host>example.url</host>
+        <port>2362</port>
+      </serverInfo>
+      <indexInfo>
+        <set identifier="info:srw/cql-context-set/1/cql-v1.1" name="cql"/>
+        <set identifier="info:srw/cql-context-set/1/dc-v1.1" name="dc"/>
+        <set identifier="http://zing.z3950.org/cql/bath/2.0/" name="bath"/>
+        <set identifier="info:srw/schema/1/marcxml-1.1" name="marcxml"/>
+        <index id="4">
+          <title>Titel</title>
+          <map><name set="marcxml">marcxml.title</name></map>
+        </index>
+        <index id="1003">
+          <title>Autor</title>
+          <map><name set="marcxml">marcxml.creator</name></map>
+        </index>
+        <index id="2007">
+          <title>GND-ID</title>
+          <map><name set="marcxml">marcxml.gndid</name></map>
+        </index>
+        <index id="21">
+          <title>Schlagwort</title>
+          <map><name set="marcxml">marcxml.subject</name></map>
+        </index>
+        <index id="7">
+          <title>ISBN</title>
+          <map><name set="marcxml">marcxml.isbn</name></map>
+        </index>
+        <index id="8">
+          <title>ISSN</title>
+          <map><name set="marcxml">marcxml.issn</name></map>
+        </index>
+        <index id="12">
+          <title>System-Nr.</title>
+          <map><name set="marcxml">rec.id</name></map>
+        </index>
+        <index id="53">
+          <title>BV-Nr.</title>
+          <map><name set="marcxml">marcxml.idn</name></map>
+        </index>
+        <index id="1052">
+          <title>ZDB-Nr.</title>
+          <map><name set="marcxml">marcxml.zdbid</name></map>
+        </index>
+        <index id="20">
+          <title>Notation</title>
+          <map><name set="marcxml">marcxml.ntn</name></map>
+        </index>
+        <index id="31">
+          <title>Erscheinungsjahr</title>
+          <map><name set="marcxml">marcxml.date</name></map>
+        </index>
+        </indexInfo>  
+    </explain></zs:recordData></zs:record></zs:explainResponse>

--- a/tests/testData/test_data.py
+++ b/tests/testData/test_data.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from src.sru_queryer.sru import SortKey
 from src.sru_queryer.sru import SRUConfiguration
@@ -344,21 +345,23 @@ def get_test_gapines_saved_sru_configuration():
     return saved_dict
 
 class TestFiles:
-  explain_response_alma = "./tests/testData/alma_explain_response.xml"
-  alma_bad_explain_response = "tests/testData/alma_bad_explain_response.xml"
-  alma_raw_indexes = "./tests/testData/alma_raw_indexes.json"
-  alma_raw_schemas = "./tests/testData/alma_raw_schemas.json"
-  alma_raw_config_info = "./tests/testData/alma_raw_config_info.json"
-  alma_available_context_sets_and_indexes = "./tests/testData/alma_available_context_sets_and_indexes.json"
+  explain_response_alma = os.path.join("tests", "testData", "alma_explain_response.xml")
+  alma_bad_explain_response = os.path.join("tests", "testData", "alma_bad_explain_response.xml")
+  alma_raw_indexes = os.path.join("tests", "testData", "alma_raw_indexes.json")
+  alma_raw_schemas = os.path.join("tests", "testData", "alma_raw_schemas.json")
+  alma_raw_config_info = os.path.join("tests", "testData", "alma_raw_config_info.json")
+  alma_available_context_sets_and_indexes = os.path.join("tests", "testData", "alma_available_context_sets_and_indexes.json")
 
-  explain_response_loc = "./tests/testData/loc_explain_response.xml"
-  loc_bad_explain_response = "tests/testData/loc_bad_explain_response.xml"
-  loc_raw_indexes = "./tests/testData/loc_raw_indexes.json"
-  loc_raw_schemas = "./tests/testData/loc_raw_schemas.json"
-  loc_available_context_sets_and_indexes = "./tests/testData/loc_available_context_sets_and_indexes.json"
+  explain_response_loc = os.path.join("tests", "testData", "loc_explain_response.xml")
+  loc_bad_explain_response = os.path.join("tests", "testData", "loc_bad_explain_response.xml")
+  loc_raw_indexes = os.path.join("tests", "testData", "loc_raw_indexes.json")
+  loc_raw_schemas = os.path.join("tests", "testData", "loc_raw_schemas.json")
+  loc_available_context_sets_and_indexes = os.path.join("tests", "testData", "loc_available_context_sets_and_indexes.json")
 
-  explain_response_gapines = "./tests/testData/gapines_explain_response.xml"
-  gapines_html_response = "./tests/testData/gapines_html_response.html"
-  gapines_raw_indexes = "./tests/testData/gapines_raw_indexes.json"
-  gapines_raw_config_info = "./tests/testData/gapines_raw_config_info.json"
-  gapines_available_context_sets_and_indexes= "./tests/testData/gapines_available_context_sets_and_indexes.json"
+  explain_response_gapines = os.path.join("tests", "testData", "gapines_explain_response.xml")
+  gapines_html_response = os.path.join("tests", "testData", "gapines_html_response.html")
+  gapines_raw_indexes = os.path.join("tests", "testData", "gapines_raw_indexes.json")
+  gapines_raw_config_info = os.path.join("tests", "testData", "gapines_raw_config_info.json")
+  gapines_available_context_sets_and_indexes = os.path.join("tests", "testData", "gapines_available_context_sets_and_indexes.json")
+
+  sru_no_schema = os.path.join("tests", "testData", "sru_no_schema.xml")

--- a/tests/test_search_retrieve.py
+++ b/tests/test_search_retrieve.py
@@ -111,6 +111,15 @@ class TestSearchRetrieve(unittest.TestCase):
         self.assertIn("'fakefake'", ve.exception.__str__())
         self.assertIn("not available", ve.exception.__str__())
 
+    def test_validate_query_that_has_no_available_record_schemas(self):
+        """Validation for record schemas should pass regardless when the explainResponse
+        doesn't contain sru information."""
+        sru_configuration = get_alma_sru_configuration()
+        sru_configuration.server_url = "https://example.com"
+        sru_configuration.sru_version = "1.2"
+        sru_configuration.available_record_schemas = None
+        SearchRetrieve(sru_configuration, SearchClause("alma", "action_note_note", "==", "10"), record_schema='fakefake').validate()
+
     def test_initialize_with_dict_correct_settings(self):
         with open("tests/testData/1_2_query_dict.json", "r") as f:
             query_dict = json.loads(f.read())

--- a/tests/test_sru_explain_auto_parser.py
+++ b/tests/test_sru_explain_auto_parser.py
@@ -245,4 +245,16 @@ class TestSRUExplainAutoParser(unittest.TestCase):
 
                 self.assertEqual(configuration.available_context_sets_and_indexes, expected_indexes)
 
+    def test_construct_sru_configuration_no_schema_info(self):
+        """Not all SRU responses contain schema info. Here, we are verifying that responses without schema info can be
+        parsed properly."""
+        with open(TestFiles.sru_no_schema, "rb") as f:
+            response_dict = xmltodict.parse(f.read())
+
+            sru_dict_parser = SRUExplainAutoParser(response_dict)
+
+            sru_configuration = sru_dict_parser.get_sru_configuration_from_explain_response()
+
+            self.assertIsNone(sru_configuration.available_record_schemas)
+
 


### PR DESCRIPTION
Explain response parsing failed when the explain response did not carry the record schema info. I had not planned for that to be empty. So, I have made the neccesary changes so that it will pass.

I also modified the test files so that they use os.path, which means the unittests should work properly on Windows. There may yet be some missing.

https://umd-dit.atlassian.net/browse/LIBILS-916